### PR TITLE
fixing _msr.jb schema so api returns more details

### DIFF
--- a/app/views/public/api/v1/lsv/type/_msr.jb
+++ b/app/views/public/api/v1/lsv/type/_msr.jb
@@ -1,3 +1,14 @@
 {
+  id: msr.id,
   type: :marketing_shipment_request,
+  subtype: msr.class.name.underscore.split("/").last,
+  path: if_expand(:path) { public_v1_lsv_path(slug, msr.id) },
+  public_url: show_lsv_url(slug, msr.id),
+  original_id: msr.source_id,
+  created_at: msr.created_at,
+  title: msr.title_text,
+  status: msr.status_text,
+  tracking_number: msr.tracking_number,
+  tracking_link: msr.tracking_link,
 }
+


### PR DESCRIPTION
Essentially, there is an issue with the api which certain types of mail(mail shipment request) don't return all the details when retrieved via the api versus what is actually seen on the ui. This should just modify the schema so that on a request, all details are provided and there shouldn't be an issue. I haven't tested this(been unable to since I've been fighting with ruby) but I believe it should work.

```jsonc
{
  "mail": [
     // ...
    {
      "type": "marketing_shipment_request"
    },
    {
      "type": "marketing_shipment_request"
    },
    // ...
  ]
}
```
![image](https://github.com/user-attachments/assets/72e91dd7-1bf3-4c55-8ebe-3adaf76a1cbc)
