### PR TITLE
Drop macondo title height

### DIFF
--- a/app/lib/snail_mail/components/templates/macondo_template.rb
+++ b/app/lib/snail_mail/components/templates/macondo_template.rb
@@ -20,7 +20,7 @@ module SnailMail
           # MACONDO header banner (watercolor stripes + straw hat + hibiscus)
           image(
             image_path("macondo/title.png"),
-            at: [ 0, 262 ],
+            at: [ 0, 248 ],
             width: 432,
           )
 


### PR DESCRIPTION
<img width="897" height="610" alt="Screenshot 2026-06-22 at 14 58 35" src="https://github.com/user-attachments/assets/e8917cf1-2bd7-4762-b237-54c8d06eaf7e" />
This drops the title + white flower down lower so it doesn't overlap with any of the top right indicia location