### PR TITLE
Remove rectangle from macondo address box

### DIFF
--- a/app/lib/snail_mail/components/templates/macondo_template.rb
+++ b/app/lib/snail_mail/components/templates/macondo_template.rb
@@ -36,7 +36,7 @@ module SnailMail
 
           render_destination_address(
             108, 172, 214, 72,
-            size: 12, valign: :center, align: :left, dbg_stroke: true
+            size: 12, valign: :center, align: :left
           )
 
           render_qr_code(8, 168, 50)


### PR DESCRIPTION
<img width="891" height="597" alt="Screenshot 2026-06-24 at 10 09 17" src="https://github.com/user-attachments/assets/65f7cfda-42f6-4d8e-a444-77af373c40a0" />

Now the destination address doesn't have a black box around it