### PR TITLE
[HCB] Request v4 API scopes for Payment Accounts

### DIFF
--- a/app/controllers/hcb/oauth_connections_controller.rb
+++ b/app/controllers/hcb/oauth_connections_controller.rb
@@ -50,7 +50,7 @@ class HCB::OauthConnectionsController < ApplicationController
   def hcb_oauth_authorize_url
     hcb_oauth_client.auth_code.authorize_url(
       redirect_uri: callback_hcb_oauth_connection_url,
-      scope: "read write",
+      scope: "restricted organizations:read transfers:write transactions:write",
     )
   end
 end


### PR DESCRIPTION
`read` and `write` are not valid scopes for HCB. This caused HCB to return errors when we started validating that requested scopes are valid.

So, this PR requests the proper scopes needed.

Dependent on https://github.com/hackclub/hcb/pull/14199