### PR TITLE
Fix positioning of stardance free sticker addresses that are 6 lines …

### DIFF
--- a/app/lib/snail_mail/components/templates/stardance_free_stickers_fulfillment_template.rb
+++ b/app/lib/snail_mail/components/templates/stardance_free_stickers_fulfillment_template.rb
@@ -24,7 +24,7 @@ module SnailMail
           )
 
           render_return_address(10, 278, 260, 70, size: 8)
-          render_destination_address(165, 140, 230, 71, size: 14, valign: :bottom, align: :left)
+          render_destination_address(165, 136, 230, 67, size: 14, valign: :bottom, align: :left)
 
           render_imb(240, 24, 183)
           render_qr_code(5, 100, 50)
@@ -38,7 +38,7 @@ module SnailMail
 
         def render_preview_bounds
           stroke_preview_bounds(10, 278, 260, 70, label: "return address")
-          stroke_preview_bounds(165, 140, 230, 71, label: "destination address")
+          stroke_preview_bounds(165, 136, 230, 67, label: "destination address")
           stroke_preview_bounds(240, 24, 183, 12, label: "IMb barcode")
           stroke_preview_bounds(5, 115, 50, 50, label: "QR code")
           stroke_preview_bounds(10, 65, 10, 60, label: "letter ID")

--- a/app/lib/snail_mail/components/templates/stardance_free_stickers_fulfillment_template.rb
+++ b/app/lib/snail_mail/components/templates/stardance_free_stickers_fulfillment_template.rb
@@ -24,7 +24,7 @@ module SnailMail
           )
 
           render_return_address(10, 278, 260, 70, size: 8)
-          render_destination_address(165, 136, 230, 67, size: 14, valign: :bottom, align: :left)
+          render_destination_address(150, 136, 260, 67, size: 14, valign: :bottom, align: :left)
 
           render_imb(240, 24, 183)
           render_qr_code(5, 100, 50)
@@ -38,7 +38,7 @@ module SnailMail
 
         def render_preview_bounds
           stroke_preview_bounds(10, 278, 260, 70, label: "return address")
-          stroke_preview_bounds(165, 136, 230, 67, label: "destination address")
+          stroke_preview_bounds(150, 136, 260, 67, label: "destination address")
           stroke_preview_bounds(240, 24, 183, 12, label: "IMb barcode")
           stroke_preview_bounds(5, 115, 50, 50, label: "QR code")
           stroke_preview_bounds(10, 65, 10, 60, label: "letter ID")


### PR DESCRIPTION
…or longer

<img width="1999" height="661" alt="44d763c8-6cae-4b49-a17e-4c345123268f" src="https://github.com/user-attachments/assets/d64cb280-bcaf-4b05-9971-51672533b2da" />
